### PR TITLE
Add status code to res.send in line 31.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ app.get("/entry/:id", async (req, res) => {
     }
     const id = parseInt(req.params.id);
     const entry = await Entry.findOne({ id: id });
-    res.send(entry.date);
+    res.status(200).send(entry.date);
 });
 app.post("/entry", async (req, res) => {
     const authorization = req.headers.authorization;


### PR DESCRIPTION
It is best practice to always explicitly send a status code. This however is missing in line 31. This PR fixes this issue.